### PR TITLE
Fix forced .png file extension

### DIFF
--- a/LiteralsExtension/ImageLiteralsConverter.swift
+++ b/LiteralsExtension/ImageLiteralsConverter.swift
@@ -9,11 +9,7 @@ struct ImageLiteralsConverter: TextConverter {
                                        range: range)
 
       for match in matches.reversed() {
-         var name = result.substring(with: match.rangeAt(1))
-         let pathExtension = (name as NSString).pathExtension
-         if pathExtension.isEmpty {
-            name = name + ".png"
-         }
+         let name = result.substring(with: match.rangeAt(1))
          result = result.replacingCharacters(in: match.range, with: "#imageLiteral(resourceName: \"\(name)\")") as NSString
       }
       return result as String


### PR DESCRIPTION
Fixes this awesome 😃 extension for resources of different types like .jpg or .pdf
If user haven't specified an extension in a resource name, #imageLiteral will still work